### PR TITLE
Fix apgdiff schema creation error

### DIFF
--- a/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/loader/PgDumpLoader.java
@@ -255,7 +255,7 @@ public class PgDumpLoader { //NOPMD
             } else if (PATTERN_CREATE_INDEX.matcher(statement).matches()) {
                 CreateIndexParser.parse(database, statement);
             } else if (PATTERN_CREATE_VIEW.matcher(statement).matches()) {
-                CreateViewParser.parse(database, statement);
+                CreateViewParser.parse(database, statement, ignoreSchemaCreation);
             } else if (PATTERN_CREATE_TRIGGER.matcher(statement).matches()) {
                 CreateTriggerParser.parse(
                         database, statement, ignoreSlonyTriggers);
@@ -266,7 +266,7 @@ public class PgDumpLoader { //NOPMD
             } else if (PATTERN_CREATE_PROCEDURE.matcher(statement).matches()) {
                 CreateProcedureParser.parse(database, statement);
             } else if (PATTERN_CREATE_TYPE.matcher(statement).matches()) {
-                CreateTypeParser.parse(database, statement);
+                CreateTypeParser.parse(database, statement, ignoreSchemaCreation);
             } else if (PATTERN_COMMENT.matcher(statement).matches()) {
                 CommentParser.parse(
                         database, statement, outputIgnoredStatements);

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTypeParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateTypeParser.java
@@ -27,7 +27,7 @@ public class CreateTypeParser {
      * @param statement CREATE TYPE statement
      */
     public static void parse(final PgDatabase database,
-            final String statement) {
+            final String statement, boolean ignoreSchemaCreation) {
         
         
         final Parser parser = new Parser(statement);
@@ -37,12 +37,17 @@ public class CreateTypeParser {
         final PgType type = new PgType(ParserUtils.getObjectName(typeName));
         final String schemaName
                 = ParserUtils.getSchemaName(typeName, database);
-        final PgSchema schema = database.getSchema(schemaName);
+        PgSchema schema = database.getSchema(schemaName);
 
         if (schema == null) {
-            throw new RuntimeException(MessageFormat.format(
+            if (ignoreSchemaCreation) {
+                schema = new PgSchema(schemaName);
+                database.addSchema(schema);
+            } else {
+                throw new RuntimeException(MessageFormat.format(
                     Resources.getString("CannotFindSchema"), schemaName,
                     statement));
+            }
         }
 
         schema.addType(type);

--- a/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateViewParser.java
+++ b/src/main/java/cz/startnet/utils/pgdiff/parsers/CreateViewParser.java
@@ -27,7 +27,7 @@ public class CreateViewParser {
      * @param statement CREATE VIEW statement
      */
     public static void parse(final PgDatabase database,
-            final String statement) {
+            final String statement, boolean ignoreSchemaCreation) {
         final Parser parser = new Parser(statement);
 
         parser.expect("CREATE");
@@ -73,12 +73,18 @@ public class CreateViewParser {
         view.setQuery(query);
 
         final String schemaName = ParserUtils.getSchemaName(viewName, database);
-        final PgSchema schema = database.getSchema(schemaName);
+        PgSchema schema = database.getSchema(schemaName);
 
         if (schema == null) {
-            throw new RuntimeException(MessageFormat.format(
+            if (ignoreSchemaCreation) {
+                schema = new PgSchema(schemaName);
+                database.addSchema(schema);
+            }
+            else {
+                throw new RuntimeException(MessageFormat.format(
                     Resources.getString("CannotFindSchema"), schemaName,
                     statement));
+            }
         }
 
         schema.addRelation(view);


### PR DESCRIPTION
* Fix apgdiff erroring out when we use ignore-schema-creation option which will skip the schema creation SQL statements.  Adds the schema to the registry.